### PR TITLE
Add support for PHP 8.2 and 8.3

### DIFF
--- a/Model/CorsCheck.php
+++ b/Model/CorsCheck.php
@@ -13,6 +13,15 @@ use SplashLab\CorsRequests\Api\CorsCheckInterface;
  */
 class CorsCheck implements CorsCheckInterface
 {
+    /**
+     * @var \Magento\Framework\Webapi\Rest\Response $response
+     */
+    private $response;
+
+    /**
+     * @var \Magento\Framework\Webapi\Rest\Request $request
+     */
+    private $request;
 
     /**
      * Initialize dependencies.

--- a/Plugin/CorsRequestOptionsPlugin.php
+++ b/Plugin/CorsRequestOptionsPlugin.php
@@ -22,7 +22,7 @@ class CorsRequestOptionsPlugin
      * Allow Options requests from jQuery AJAX
      *
      * @param Request $subject
-     * @return void
+     * @return string
      * @throws InputException
      */
     public function aroundGetHttpMethod(

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Enabling cross-origin resource sharing (CORS) requests to Magento 2 API from configured Origin domain",
     "homepage": "https://github.com/splashlab/magento-2-cors-requests",
     "type": "magento2-module",
-    "version": "100.0.7",
+    "version": "100.0.8",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -13,8 +13,9 @@
         "source": "https://github.com/splashlab/magento-2-cors-requests"
     },
     "require": {
-        "php": "~7.1.3||~7.2.0||~7.3.0||~7.4.0||~8.1.0",
-        "magento/framework": "*"
+        "php": "~7.1.3||~7.2.0||~7.3.0||~7.4.0||~8.1.0||~8.2.0||~8.3.0",
+        "magento/framework": "*",
+        "magento/module-webapi": "*"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Hello, changes are mostly already in the title.

In PHP8.2 dynamic declarations of properties were deprecated, so I fixed it. 

Also, the module depends on `magento/module-webapi` so I declared it in composer.json too.